### PR TITLE
Add error handling for mNandaRegistry initialization

### DIFF
--- a/inc/js/agents/system/connector-agent.mjs
+++ b/inc/js/agents/system/connector-agent.mjs
@@ -246,6 +246,10 @@ class nandaRegistry {
 }
 /* modular functions */
 /* bootstrapped functions */
-mNandaRegistry = await new nandaRegistry(mNandaRegistryUrl).init()
+try{
+	mNandaRegistry = await new nandaRegistry(mNandaRegistryUrl).init()
+} catch(err) {
+	console.error('connector-agent.mjs::bootstrap::mNandaRegistry ERROR::', err)
+}
 /* module exports */
 export default ConnectorAgent


### PR DESCRIPTION
Wrap initialization of mNandaRegistry in a try-catch block to handle errors.