### PR TITLE
Restore session param on Avatar.configure()

### DIFF
--- a/inc/js/avatar.mjs
+++ b/inc/js/avatar.mjs
@@ -897,7 +897,7 @@ class Avatar extends EventEmitter {
      *   - type: Type of configuration (optional)
      * @returns {Promise<object>} - The response object containing the configuration details.
      */
-    async configure(params={}){
+    async configure(params={}, session={}){
         const { adaid, aid, bid, mbr, mid, vld, type, ...rest } = params
         const response = {
             activeBot: undefined,


### PR DESCRIPTION
## Summary

`Avatar.configure(params, session)` signature was dropping `session` on repeated merges, causing `ctx.session` to be passed from the controller but silently ignored. One-line restore.

## Changes

**`inc/js/avatar.mjs`**
- `async configure(params={}, session={})` — restores session parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)